### PR TITLE
Time picker

### DIFF
--- a/proofOC/bookRoom.py
+++ b/proofOC/bookRoom.py
@@ -7,8 +7,10 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from kivy.app import App
 from kivy.uix.screenmanager import ScreenManager, Screen, NoTransition
+
+from kivymd.app import MDApp
+from kivymd.uix.picker import MDTimePicker
 
 import time
 import datetime
@@ -18,22 +20,41 @@ import loginWindow
 class BookingScreen(Screen):
     pass
 
-class TestApp(App):
+class TestApp(MDApp):
 
     userN=passW=""
    
     def build(self):
         return BookingScreen()
+
+    def get_time(self, instance, time):
+        formatted_time = time.strftime("%I:%M %p")
+        self.root.ids.time.text = str(formatted_time)
+
+    def on_time_cancel(self, instance, time):
+        # when canceling time selection from the widget don't do anything
+        pass
+
+    def show_time_picker(self):
+        time_selector = MDTimePicker()
+        time_selector.bind(on_cancel=self.on_time_cancel, time=self.get_time)
+        time_selector.open()
   
     def transformData(self, timeS, roomNum, date):
         try:
             result = list(map(lambda v: v.strip().lower(), [timeS, roomNum, date]))
             if(not timeS or not roomNum or not date):
                 return None
+
             select = datetime.datetime.strptime(result[2], "%m-%d-%Y").date()
             fullDate = select.strftime("%B %d, %Y")
             weekday = calendar.day_name[select.weekday()]
-            selectTime = (f"{result[0]} {weekday}, {fullDate} - {result[1]} - Available")
+
+            time = "".join(result[0].split()) # removes any inner whitespace
+            time = time if time[0] != '0' else time[1:] # removes leading zero if present
+
+            selectTime = (f"{time} {weekday}, {fullDate} - {result[1]} - Available")
+            print(selectTime)
             return selectTime
         except:
             return None

--- a/proofOC/bookRoom.py
+++ b/proofOC/bookRoom.py
@@ -28,6 +28,9 @@ class TestApp(MDApp):
         return BookingScreen()
 
     def get_time(self, instance, time):
+        return time
+
+    def on_time_save(self, instance, time):
         formatted_time = time.strftime("%I:%M %p")
         self.root.ids.time.text = str(formatted_time)
 
@@ -37,7 +40,7 @@ class TestApp(MDApp):
 
     def show_time_picker(self):
         time_selector = MDTimePicker()
-        time_selector.bind(on_cancel=self.on_time_cancel, time=self.get_time)
+        time_selector.bind(on_cancel=self.on_time_cancel, on_save=self.on_time_save, time=self.get_time)
         time_selector.open()
   
     def transformData(self, timeS, roomNum, date):

--- a/proofOC/test.kv
+++ b/proofOC/test.kv
@@ -17,9 +17,22 @@
         TextInput:
             id: roomNumber
             hint_text: 'Room #: '
-        TextInput:
-            id: time
-            hint_text: 'Time: [H:MMpm or H:MMam]'
+
+        GridLayout:
+            cols: 2
+            AnchorLayout:
+                anchor_x: 'left'
+                MDRaisedButton:
+                    text: 'Select Time'
+                    on_release: app.show_time_picker()
+                    pos_hint: {'center_x': .5, 'center_y': .5}
+
+            AnchorLayout:  
+                anchor_x: 'right'  
+                MDLabel:
+                    id: time
+                    text: 'No time chosen'
+                    halign: 'right'
 
         Button:
             id: submit

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,10 @@ h11==0.13.0
 idna==3.3
 Kivy==2.1.0
 Kivy-Garden==0.1.5
+kivymd==0.104.2
 macholib==1.16
 outcome==1.1.0
+Pillow==9.0.1
 pycparser==2.21
 Pygments==2.11.2
 pyinstaller==4.10


### PR DESCRIPTION
This PR addresses issue #21 and improves the way we select a time. This uses KivyMD on top of Kivy to allow us to access different widgets to use for our inputs. Time selection now looks like this:

![Screen Shot 2022-03-28 at 12 22 20 PM](https://user-images.githubusercontent.com/52588047/160445430-c5f7d6bb-e7c2-4f52-a979-be9d67a5c55a.jpg)

Also updated `requirements.txt` with new dependency.

As a side effect, the color scheme now defaults to light instead of dark. If we wish to change this back I can do so in a separate PR (dark mode best mode)