### PR TITLE
new: connect github and send booking to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 personas/
 .DS_Store
 venv/
+local_repo/

--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@ For Temple students who need to schedule rooms in Charles Library farther in adv
 
 # How to run
 
-- For MacOS users :
+## Prerequisites
+
+- You'll need a [Github account](https://github.com/) and a [private repository](https://docs.github.com/en/get-started/quickstart/create-a-repo) to save booking information in. _Note: your Temple username and password will be stored here for the scheduler to remotely access your account, so MAKE SURE the repo is private!_
+
+## For MacOS users :
+
 - Download the latest zip from the Release section on the right on GitHub.
 - Extract the bookRoom.dmg file from the zip and open it
 - Right click on the bookRoom.app file inside and click 'Open'. A popup will be appear claiming the file is not safe.
 - Repeat the previous step. This time, the popup should have the option 'Open'. Click it and the application should load.
 
-- For Windows users :
+## For Windows/Linux users :
+
 - Clone the repository (using git clone command)
 - Make sure python 3.6+ is installed and can be run from the command line
 - Navigate to the location your cloned repo is (use the cd command)
@@ -22,7 +28,7 @@ For Temple students who need to schedule rooms in Charles Library farther in adv
 
 # How to contribute
 
-Follow this project board to know the latest status of the project: [http://...]([https://github.com/cis3296s22/libraryroomscheduler/projects/2])
+Follow the [project board](https://github.com/cis3296s22/libraryroomscheduler/projects/2) to know the latest status of the project.
 
 ## How to build
 

--- a/proofOC/BookingBuilder.py
+++ b/proofOC/BookingBuilder.py
@@ -1,0 +1,25 @@
+from ast import Str
+import os.path
+
+class BookingBuilder:
+  def __init__(self, username: str, password: str):
+    """
+    Creates a bookings history file only if it doesn't exist.
+    The username and password are stored on the first line and used to 
+    automate the scheduling.
+    """
+    self.fileName = "bookings.csv"
+    self.fullPath = f"local_repo/{self.fileName}"
+
+    if not os.path.isfile(self.fullPath):
+    # create the first line with user/pass if it doesn't exist
+      with open(self.fullPath, "w+") as f:
+        f.write(f"{username},{password}\n")
+
+  def addBooking(self, date:str, size:str):
+    """
+    Adds a booking to the csv with each value wrapped in double quotes.
+    """
+    # TODO do we want to validate date/time here?
+    with open(self.fullPath, "a+") as f:
+      f.write(f'"{date}","{size}"\n')

--- a/proofOC/RepoCommunicator.py
+++ b/proofOC/RepoCommunicator.py
@@ -1,0 +1,60 @@
+import sys
+import git
+import os
+
+def remoteRepoConfigured(repoPath: str):
+  if os.path.exists(f"{repoPath}/remoteURL.txt"):
+    with open(f"{repoPath}/remoteURL.txt", "r") as f:
+      return f.readline().rstrip()
+  return ""
+
+class RepoCommunicator:
+
+  def __init__(self, remoteRepoUrl: str, localPath: str):
+    """
+    Instantiates the local repository to comminucate with GitHub.
+    If the local repo has not been created, it will create one.
+    """
+    self.remoteRepoUrl = remoteRepoUrl
+    self.localPath = localPath
+
+    if not os.path.exists(localPath):
+    # path doesn't exist, create it
+      os.mkdir(localPath)
+
+    if os.path.exists(localPath) and os.path.isdir(localPath):
+    # path exists and is a directory
+      if len(os.listdir(localPath)):
+      # it's not empty, set local to it
+        self.repo = git.Repo(os.path.realpath(localPath))
+        # if remote file doesn't exist, recreate it
+        # TODO validate this with git remote instead of string passed in
+        with open(f"{localPath}/remoteURL.txt", "w+") as f:
+            f.write(remoteRepoUrl)
+      else:
+      # it's empty, clone into it
+        try:
+          self.repo = git.Repo.clone_from(remoteRepoUrl, localPath)
+          with open(f"{localPath}/remoteURL.txt", "w+") as f:
+            f.write(remoteRepoUrl)
+
+        except Exception as e:
+          sys.exit(f"An error occurred in cloning the repo:\n{e}")
+    else:
+    # path exists but is not a directory
+    # this "shouldn't" trigger since the dir is hardcoded
+      sys.exit("Please provide a directory for the local repository")
+
+
+  def addFile(self, fileName):
+    """
+    Stages a file for commit
+    """
+    self.repo.index.add(fileName)
+
+  def pushData(self):
+    """
+    Pushes the local repo up to GitHub
+    """
+    self.repo.index.commit('Update bookings.')
+    self.repo.remotes.origin.push()

--- a/proofOC/bookRoom.py
+++ b/proofOC/bookRoom.py
@@ -96,10 +96,11 @@ class TestApp(MDApp):
             return False
 
         # save booking to file
+        repo = RepoCommunicator(repoUrl, self.repoPath)
+
         bookings = BookingBuilder(self.userN, self.passW)
         bookings.addBooking(dateString, roomSize)
 
-        repo = RepoCommunicator(repoUrl, self.repoPath)
         repo.addFile(bookings.fileName)
         repo.pushData()
 

--- a/proofOC/bookRoom.py
+++ b/proofOC/bookRoom.py
@@ -20,18 +20,25 @@ import datetime
 import calendar
 import loginWindow
 
+from BookingBuilder import BookingBuilder
+from RepoCommunicator import RepoCommunicator, remoteRepoConfigured
+
 class BookingScreen(Screen):
     pass
 
 class TestApp(MDApp):
 
-    userN=passW=""
+    userN=passW=repoUrl=""
+    repoPath = "local_repo"
+    repoUrl = remoteRepoConfigured(repoPath)
    
     def build(self):
         self.theme_cls.primary_palette = "Green"
         self.theme_cls.primary_hue = "200" 
-        self.theme_cls.theme_style = "Dark" 
-        return BookingScreen()
+        self.theme_cls.theme_style = "Dark"
+        root = BookingScreen()
+        root.ids.repoUrl.text = self.repoUrl
+        return root
 
     def get_time(self, instance, time):
         return time
@@ -80,13 +87,22 @@ class TestApp(MDApp):
             return None
         
 
-    def bookRoom(self, roomSize, timeS, roomNum, date):
+    def bookRoom(self, roomSize, timeS, roomNum, date, repoUrl):
 
         roomSize = roomSize.strip().lower()
         dateString = self.transformData(timeS, roomNum, date)
         if(dateString==None or (roomSize!="small" and roomSize!="large")):
             print('Incorrect Entry/Format')
             return False
+
+        # save booking to file
+        bookings = BookingBuilder(self.userN, self.passW)
+        bookings.addBooking(dateString, roomSize)
+
+        repo = RepoCommunicator(repoUrl, self.repoPath)
+        repo.addFile(bookings.fileName)
+        repo.pushData()
+
 
         service = Service(executable_path=ChromeDriverManager().install())
         driver = webdriver.Chrome(service=service)

--- a/proofOC/main.py
+++ b/proofOC/main.py
@@ -15,6 +15,9 @@ import time
 import datetime
 import calendar
 
+from RepoCommunicator import RepoCommunicator, remoteRepoConfigured
+from BookingBuilder import BookingBuilder
+
 
 def login(user, passW, dateString, roomSize):
     
@@ -91,6 +94,11 @@ driver = webdriver.Chrome(service=service)
 
 try:
     # User input (username, password, booking details)
+    repoPath = "local_repo"
+    repoUrl = remoteRepoConfigured(repoPath)
+    if not repoUrl:
+        repoUrl = input("Enter clone URL for GitHub repo: ")
+
     user = input("Enter TU User: ")
     passW = getpass.getpass("Enter Password: ")
     dateC = input("Enter Date of Booking [FORMAT MM-dd-YYYY]: ")
@@ -98,9 +106,16 @@ try:
     room = input("Enter Room #: ")
     timeSlot = input("Enter Time [FORMAT H:MMpm or H:MMam]: ")
 
-   
+    repo = RepoCommunicator(repoUrl, repoPath)
+    bookings = BookingBuilder(user, passW)
 
     dateString = transformData(timeSlot, room, dateC)
+
+    bookings.addBooking(dateString, roomSize)
+
+    repo.addFile(bookings.fileName)
+    repo.pushData()
+
     login(user, passW, dateString, roomSize)
 
 

--- a/proofOC/test.kv
+++ b/proofOC/test.kv
@@ -7,6 +7,10 @@
         size_hint: None, None
         size: root.width * .5, root.width * .5
 
+        MDTextField:
+            id: repoUrl
+            hint_text: 'Enter the clone URL for the remote repository'
+
         GridLayout:
             cols: 2
             AnchorLayout:
@@ -54,7 +58,7 @@
         Button:
             id: submit
             text: 'Submit'
-            on_press: app.bookRoom(roomSize.text, time.text, roomNumber.text, date.text)
+            on_press: app.bookRoom(roomSize.text, time.text, roomNumber.text, date.text, repoUrl.text)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 cryptography==36.0.2
 docutils==0.18.1
+gitdb==4.0.9
+GitPython==3.1.27
 h11==0.13.0
 idna==3.3
 Kivy==2.1.0
@@ -22,6 +24,7 @@ pyOpenSSL==22.0.0
 PySocks==1.7.1
 requests==2.27.1
 selenium==4.1.3
+smmap==5.0.0
 sniffio==1.2.0
 sortedcontainers==2.4.0
 trio==0.20.0


### PR DESCRIPTION
Addresses #32

## `RepoCommunicator`
- Inits a local repo to push data to github
- Clones remote repo into new directory on first run, otherwise just attaches to local repo
- Abstracts `git` commands
- Pushes booking data to github to be handled with github actions

## `BookingBuilder`
- Stores booking information in a CSV
- First line is TU username and password
- Subsequent lines are formatted booking information. Quotes are used around data since the date string has commas in it (and we want that as a single data point)

If a remote repo URL is saved, it will populate and the user will not be asked when launching the app