### PR TITLE
bug: fixed case where repo folders where created but files were not

### DIFF
--- a/proofOC/RepoCommunicator.py
+++ b/proofOC/RepoCommunicator.py
@@ -63,7 +63,6 @@ class RepoCommunicator:
     if not os.path.exists(self.workflowPath):
       try:
         os.makedirs(self.workflowPath)
-        os.popen('cp proofOC/actions/main.yml ' + self.workflowPath)
       except:
         self.logger.exception("Unable to create workflows directory.")
         raise RepositoryConfigurationException("Unable to create workflows directory.")
@@ -73,13 +72,19 @@ class RepoCommunicator:
     if not os.path.exists(self.actionsPath):
       try:
         os.makedirs(self.actionsPath)
-        os.popen('cp proofOC/actions/actionScript.py ' + self.actionsPath)
-        os.popen('cp proofOC/actions/TraverseSite.py ' + self.actionsPath)
-        os.popen('cp proofOC/actions/requirements.txt ' + self.actionsPath)
       except:
         self.logger.exception("Unable to create actions directory.")
         raise RepositoryConfigurationException("Unable to create actions directory.")
 
+    # always copy the latest files
+    try:
+      os.popen('cp proofOC/actions/main.yml ' + self.workflowPath)
+      os.popen('cp proofOC/actions/actionScript.py ' + self.actionsPath)
+      os.popen('cp proofOC/actions/TraverseSite.py ' + self.actionsPath)
+      os.popen('cp proofOC/actions/requirements.txt ' + self.actionsPath)
+    except:
+      self.logger.exception("Error copying github action files to local repository")
+      raise RepositoryConfigurationException("Error creating github action files. See app.log for more details")
 
 
     


### PR DESCRIPTION
If there's a situation where the folders necessary for the github actions were created, but the files were not copied over, they would never be copied into the local repo. This pulls the copying of the files out of the folder creation logic, so files will be copied over every time. This also allows for the most up to date config files to be pushed to the user's repo if we need to update them later.